### PR TITLE
Fix : "도메인 별 Entity 수정"

### DIFF
--- a/src/main/java/com/example/airdns/domain/chatting/entity/Chatting.java
+++ b/src/main/java/com/example/airdns/domain/chatting/entity/Chatting.java
@@ -4,10 +4,7 @@ package com.example.airdns.domain.chatting.entity;
 import com.example.airdns.domain.chattinguser.entity.ChattingUsers;
 import com.example.airdns.global.common.entity.CommonEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +14,7 @@ import java.util.List;
 @Builder
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Chatting extends CommonEntity {
 
     @Id

--- a/src/main/java/com/example/airdns/domain/chattinguser/entity/ChattingUsers.java
+++ b/src/main/java/com/example/airdns/domain/chattinguser/entity/ChattingUsers.java
@@ -4,17 +4,14 @@ import com.example.airdns.domain.chatting.entity.Chatting;
 import com.example.airdns.domain.user.entity.Users;
 import com.example.airdns.global.common.entity.CommonEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "chatting_users")
 @Builder
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChattingUsers extends CommonEntity {
 
     @Id

--- a/src/main/java/com/example/airdns/domain/equipment/entity/Equipments.java
+++ b/src/main/java/com/example/airdns/domain/equipment/entity/Equipments.java
@@ -5,10 +5,7 @@ import com.example.airdns.domain.equipmentcategory.entity.EquipmentCategories;
 import com.example.airdns.domain.roomequipment.entity.RoomEquipments;
 import com.example.airdns.global.common.entity.CommonEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +15,7 @@ import java.util.List;
 @Builder
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Equipments extends CommonEntity {
 
     @Id

--- a/src/main/java/com/example/airdns/domain/equipmentcategory/entity/EquipmentCategories.java
+++ b/src/main/java/com/example/airdns/domain/equipmentcategory/entity/EquipmentCategories.java
@@ -1,11 +1,9 @@
 package com.example.airdns.domain.equipmentcategory.entity;
 
 import com.example.airdns.domain.equipment.entity.Equipments;
+import com.example.airdns.global.common.entity.CommonEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,8 +13,8 @@ import java.util.List;
 @Builder
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class EquipmentCategories {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EquipmentCategories extends CommonEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/airdns/domain/holiday/entity/Holidays.java
+++ b/src/main/java/com/example/airdns/domain/holiday/entity/Holidays.java
@@ -3,10 +3,7 @@ package com.example.airdns.domain.holiday.entity;
 import com.example.airdns.domain.room.entity.Rooms;
 import com.example.airdns.global.common.entity.CommonEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -15,7 +12,7 @@ import java.time.LocalDateTime;
 @Builder
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Holidays extends CommonEntity {
 
     @Id

--- a/src/main/java/com/example/airdns/domain/image/entity/Images.java
+++ b/src/main/java/com/example/airdns/domain/image/entity/Images.java
@@ -4,17 +4,14 @@ package com.example.airdns.domain.image.entity;
 import com.example.airdns.domain.room.entity.Rooms;
 import com.example.airdns.global.common.entity.CommonEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "images")
 @Builder
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Images extends CommonEntity {
 
     @Id

--- a/src/main/java/com/example/airdns/domain/like/entity/Likes.java
+++ b/src/main/java/com/example/airdns/domain/like/entity/Likes.java
@@ -5,17 +5,14 @@ import com.example.airdns.domain.room.entity.Rooms;
 import com.example.airdns.domain.user.entity.Users;
 import com.example.airdns.global.common.entity.CommonEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "likes")
 @Builder
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Likes extends CommonEntity {
 
     @Id

--- a/src/main/java/com/example/airdns/domain/payment/entity/Payments.java
+++ b/src/main/java/com/example/airdns/domain/payment/entity/Payments.java
@@ -3,17 +3,14 @@ package com.example.airdns.domain.payment.entity;
 import com.example.airdns.domain.reservation.entity.Reservation;
 import com.example.airdns.global.common.entity.CommonEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "payments")
 @Builder
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Payments extends CommonEntity {
 
     @Id

--- a/src/main/java/com/example/airdns/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/example/airdns/domain/reservation/entity/Reservation.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE reservaion SET is_deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE reservation SET is_deleted = true WHERE id = ?")
 public class Reservation extends CommonEntity {
 
     @Id

--- a/src/main/java/com/example/airdns/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/example/airdns/domain/reservation/entity/Reservation.java
@@ -5,21 +5,18 @@ import com.example.airdns.domain.room.entity.Rooms;
 import com.example.airdns.domain.user.entity.Users;
 import com.example.airdns.global.common.entity.CommonEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "reservaion")
+@Table(name = "reservation")
 @Builder
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-@SQLDelete(sql = "UPDATE reservation SET deleted = true WHERE id = ?")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE reservaion SET is_deleted = true WHERE id = ?")
 public class Reservation extends CommonEntity {
 
     @Id

--- a/src/main/java/com/example/airdns/domain/review/entity/Reviews.java
+++ b/src/main/java/com/example/airdns/domain/review/entity/Reviews.java
@@ -4,17 +4,14 @@ import com.example.airdns.domain.room.entity.Rooms;
 import com.example.airdns.domain.user.entity.Users;
 import com.example.airdns.global.common.entity.CommonEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "reviews")
 @Builder
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Reviews extends CommonEntity {
 
     @Id

--- a/src/main/java/com/example/airdns/domain/room/entity/Rooms.java
+++ b/src/main/java/com/example/airdns/domain/room/entity/Rooms.java
@@ -9,10 +9,7 @@ import com.example.airdns.domain.roomequipment.entity.RoomEquipments;
 import com.example.airdns.domain.user.entity.Users;
 import com.example.airdns.global.common.entity.CommonEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDateTime;
@@ -24,8 +21,8 @@ import java.util.List;
 @Builder
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-@SQLDelete(sql = "UPDATE rooms SET deleted = true WHERE id = ?")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE rooms SET is_deleted = true WHERE id = ?")
 public class Rooms extends CommonEntity {
 
     @Id

--- a/src/main/java/com/example/airdns/domain/roomequipment/entity/RoomEquipments.java
+++ b/src/main/java/com/example/airdns/domain/roomequipment/entity/RoomEquipments.java
@@ -4,17 +4,14 @@ import com.example.airdns.domain.equipment.entity.Equipments;
 import com.example.airdns.domain.room.entity.Rooms;
 import com.example.airdns.global.common.entity.CommonEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "room_equipments")
 @Builder
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RoomEquipments extends CommonEntity {
 
     @Id


### PR DESCRIPTION
도메인 별 Entity 오타 관련 수정
기본 생성자 AccessLevel Protected로 설정
- 지연로딩일 경우 proxy객체를 생성하는데 Private일 경우 프록시 객체를 생성 할 수 없고, public일 경우 무분별하게 데이터가 변경 될 수 있기 때문에 수정

Resolves: #1
Related to: #1