### PR TITLE
feat: "equipment list 조회 API 추가"

### DIFF
--- a/src/main/java/com/example/airdns/domain/equipment/controller/EquipmentsController.java
+++ b/src/main/java/com/example/airdns/domain/equipment/controller/EquipmentsController.java
@@ -1,0 +1,41 @@
+package com.example.airdns.domain.equipment.controller;
+
+import com.example.airdns.domain.equipment.service.EquipmentsService;
+import com.example.airdns.global.common.dto.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Tag(name = "Equipments", description = "Equipments API")
+@RestController
+public class EquipmentsController {
+
+    private final EquipmentsService equipmentsService;
+
+    @GetMapping("/equipments")
+    @Operation(summary = "장비 전체 조회", description = "장비 정보를 조회한다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "장비 정보 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 요청")
+    })
+    public ResponseEntity<CommonResponse<List<Map<String, Object>>>> readEquipmentsList() {
+        return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse<>(
+                HttpStatus.OK,
+                "장비 정보 조회에 성공했습니다",
+                equipmentsService.readEquipmentsList()
+        ));
+    }
+
+}

--- a/src/main/java/com/example/airdns/domain/equipment/dto/EquipmentsResponseDto.java
+++ b/src/main/java/com/example/airdns/domain/equipment/dto/EquipmentsResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.airdns.domain.equipment.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public class EquipmentsResponseDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReadEquipmentsResponseDto {
+        private Long id;
+        private String name;
+    }
+
+}

--- a/src/main/java/com/example/airdns/domain/equipment/service/EquipmentsService.java
+++ b/src/main/java/com/example/airdns/domain/equipment/service/EquipmentsService.java
@@ -1,13 +1,15 @@
 package com.example.airdns.domain.equipment.service;
 
 import com.example.airdns.domain.equipment.entity.Equipments;
-import com.example.airdns.domain.image.entity.Images;
-import com.example.airdns.domain.room.entity.Rooms;
+
+import java.util.List;
+import java.util.Map;
 
 public interface EquipmentsService {
 
     Equipments createEquipments();
 
+    List<Map<String, Object>> readEquipmentsList();
 
     Equipments findById(Long equipments_id);
 }

--- a/src/main/java/com/example/airdns/domain/equipment/service/EquipmentsServiceImplV1.java
+++ b/src/main/java/com/example/airdns/domain/equipment/service/EquipmentsServiceImplV1.java
@@ -1,17 +1,25 @@
 package com.example.airdns.domain.equipment.service;
 
+import com.example.airdns.domain.equipment.dto.EquipmentsResponseDto;
 import com.example.airdns.domain.equipment.entity.Equipments;
 import com.example.airdns.domain.equipment.exception.EquipmentsCustomException;
 import com.example.airdns.domain.equipment.exception.EquipmentsExceptionCode;
 import com.example.airdns.domain.equipment.repository.EquipmentsRepository;
+import com.example.airdns.domain.equipmentcategory.service.EquipmentCategoriesService;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @AllArgsConstructor
 public class EquipmentsServiceImplV1 implements EquipmentsService {
 
     private final EquipmentsRepository equipmentsRepository;
+    private final EquipmentCategoriesService equipmentCategoriesService;
 
     @Override
     public Equipments createEquipments() {
@@ -20,8 +28,44 @@ public class EquipmentsServiceImplV1 implements EquipmentsService {
     }
 
     @Override
+    public List<Map<String, Object>> readEquipmentsList() {
+        List<Map<String, Object>> returnList = new ArrayList<>(); //클라이언트 요청 형태대로 내려줌
+
+        // map (CategoryId, equipment) 생성
+        Map<Long, List<EquipmentsResponseDto.ReadEquipmentsResponseDto>> equipmentsMap = new HashMap<>();
+
+        equipmentsRepository.findAll()
+                .forEach(equipments -> {
+                    Long categoryId = equipments.getEquipmentCategories().getId();
+                    List<EquipmentsResponseDto.ReadEquipmentsResponseDto> responseList =
+                            equipmentsMap.getOrDefault(categoryId, new ArrayList<>());
+
+                    responseList.add(
+                            EquipmentsResponseDto.ReadEquipmentsResponseDto.builder()
+                                    .id(equipments.getId())
+                                    .name(equipments.getName())
+                                    .build()
+                    );
+
+                    equipmentsMap.put(categoryId, responseList);
+                });
+
+        // 카테고리 순서대로 정렬
+        equipmentCategoriesService.findAll()
+                .forEach(category -> {
+                    Map<String, Object> categoryResponseMap = new HashMap<>();
+                    categoryResponseMap.put("label", category.getName());
+                    categoryResponseMap.put("options", equipmentsMap.get(category.getId()));
+                    returnList.add(categoryResponseMap);
+                });
+
+        return returnList;
+    }
+
+    @Override
     public Equipments findById(Long equipments_id) {
         return equipmentsRepository.findById(equipments_id)
                 .orElseThrow(() -> new EquipmentsCustomException(EquipmentsExceptionCode.INVALID_EQUIPMENTS_ID));
     }
+
 }

--- a/src/main/java/com/example/airdns/domain/equipmentcategory/repository/EquipmentCategoriesRepository.java
+++ b/src/main/java/com/example/airdns/domain/equipmentcategory/repository/EquipmentCategoriesRepository.java
@@ -1,0 +1,8 @@
+package com.example.airdns.domain.equipmentcategory.repository;
+
+import com.example.airdns.domain.equipmentcategory.entity.EquipmentCategories;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EquipmentCategoriesRepository extends JpaRepository<EquipmentCategories, Long> {
+
+}

--- a/src/main/java/com/example/airdns/domain/equipmentcategory/service/EquipmentCategoriesService.java
+++ b/src/main/java/com/example/airdns/domain/equipmentcategory/service/EquipmentCategoriesService.java
@@ -1,0 +1,9 @@
+package com.example.airdns.domain.equipmentcategory.service;
+
+import com.example.airdns.domain.equipmentcategory.entity.EquipmentCategories;
+
+import java.util.List;
+
+public interface EquipmentCategoriesService {
+    List<EquipmentCategories> findAll();
+}

--- a/src/main/java/com/example/airdns/domain/equipmentcategory/service/EquipmentCategoriesServiceImplV1.java
+++ b/src/main/java/com/example/airdns/domain/equipmentcategory/service/EquipmentCategoriesServiceImplV1.java
@@ -1,0 +1,21 @@
+package com.example.airdns.domain.equipmentcategory.service;
+
+import com.example.airdns.domain.equipmentcategory.entity.EquipmentCategories;
+import com.example.airdns.domain.equipmentcategory.repository.EquipmentCategoriesRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class EquipmentCategoriesServiceImplV1 implements EquipmentCategoriesService {
+
+    private final EquipmentCategoriesRepository equipmentCategoriesRepository;
+
+    @Override
+    public List<EquipmentCategories> findAll() {
+        return equipmentCategoriesRepository.findAll();
+    }
+
+}

--- a/src/main/java/com/example/airdns/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/airdns/global/config/WebSecurityConfig.java
@@ -59,6 +59,7 @@ public class WebSecurityConfig {
                 .cors(corsConfigure -> corsConfigure.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests((requests) -> requests
                         .requestMatchers(HttpMethod.GET, "/api/v1/rooms/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/equipments").permitAll()
                         // swagger v3
                         .requestMatchers("/v3/api-docs", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
                         .requestMatchers("/login").permitAll()


### PR DESCRIPTION
권한 예외 로직 추가
데이터형태를 클라이언트 요청에 맞게 수정
```
        {
            "options": [
                {
                    "id": 3,
                    "name": "Microwave"
                }
            ],
            "label": "Kitchen Appliances"
        },
```

Resolves: #64