### PR TITLE
Refactor : Scheduler 쿼리 최적화

### DIFF
--- a/src/main/java/com/example/airdns/domain/deleteinfo/service/DeleteInfoServiceImpl.java
+++ b/src/main/java/com/example/airdns/domain/deleteinfo/service/DeleteInfoServiceImpl.java
@@ -50,16 +50,20 @@ public class DeleteInfoServiceImpl implements DeleteInfoService{
     public void saveDeletedRoomsInfo(Rooms room){
 
         // 1차 캐시에 있는 Rooms의 정보를 먼저 가져와서 넣기
-        Rooms saveRoom = em.find(Rooms.class, room.getId());
+        // Rooms saveRoom = em.find(Rooms.class, room.getId());
+        Rooms saveRoom = em.createQuery(
+                        "SELECT r FROM Rooms r JOIN FETCH r.users WHERE r.id = :roomId", Rooms.class)
+                .setParameter("roomId", room.getId())
+                .getSingleResult();
 
         deleteRoomsInfoRepository.save(
                 DeleteRoomsInfo.builder()
                         .deletedAt(LocalDateTime.now())
-                        .name(room.getName())
-                        .price(room.getPrice())
-                        .address(room.getAddress())
-                        .size(room.getSize())
-                        .description(room.getDescription())
+                        .name(saveRoom.getName())
+                        .price(saveRoom.getPrice())
+                        .address(saveRoom.getAddress())
+                        .size(saveRoom.getSize())
+                        .description(saveRoom.getDescription())
                         .owner(saveRoom.getUsers().getNickname())
                         .build()
         );
@@ -69,13 +73,16 @@ public class DeleteInfoServiceImpl implements DeleteInfoService{
     @Transactional
     public void saveDeletedReservationInfo(Reservation reservation){
 
-        Reservation saveReservation = em.find(Reservation.class, reservation.getId());
+        Reservation saveReservation = em.createQuery(
+                        "SELECT res FROM Reservation res JOIN FETCH res.rooms r JOIN FETCH res.users u WHERE res.id = :reservationId", Reservation.class)
+                .setParameter("reservationId", reservation.getId())
+                .getSingleResult();
 
         deleteReservationInfoRepository.save(
                 DeleteReservationsInfo.builder()
                         .cancelledAt(LocalDateTime.now())
-                        .checkIn(reservation.getCheckIn())
-                        .checkOut(reservation.getCheckOut())
+                        .checkIn(saveReservation.getCheckIn())
+                        .checkOut(saveReservation.getCheckOut())
                         .roomName(saveReservation.getRooms().getName())
                         .reserverName(saveReservation.getUsers().getNickname())
                         .build()


### PR DESCRIPTION
saveDeleteInfoServiceImpl EntityManager.find()를 사용하여 조회에서 N+1 문제 발생, 이로 인한 JPQL사용으로 변경
** 소량의 데이터 처리는 entityManager.find()이 적절 // 1차 캐시에 있는 내용을 가져다 쓰기 때문
** 대량의 데이터 처리는 JPQL 사용이 적절 // 한 번의 호출로 연관된 여러 엔티티를 가져올 수 있기 때문
** 해당 사항을 고려했을 때, 프로젝트 규모면에서는 entityManager.find()가 적절하나 확장성면에서 JQPL이 적절하다고 판단하여 사용하게 됨
