### PR TITLE
Refactor : 방에 대한 유저 액션 수정에 대한 변경작업

### DIFF
--- a/src/main/java/com/example/airdns/domain/like/controller/LikesController.java
+++ b/src/main/java/com/example/airdns/domain/like/controller/LikesController.java
@@ -14,8 +14,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "like", description = "Like API")
@@ -46,18 +44,17 @@ public class LikesController {
             @PathVariable Long roomsId,
             @AuthenticationPrincipal UserDetailsImpl userDetails){
         LikesResponseDto.CreateLikeResponseDto responseDto = likesService.createLike(roomsId, userDetails.getUser());
-        // ok
         return ResponseEntity.status(HttpStatus.OK).body(
                 new CommonResponse<>(HttpStatus.OK, "룸 좋아요 성공", responseDto)
         );
     }
 
     @DeleteMapping("/{roomsId}/likes/{likeId}")
+    @SecurityRequirement(name = "Bearer Authentication")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "룸 좋아요 취소 성공"),
             @ApiResponse(responseCode = "400", description = "해당 사용자가 좋아요를 누르지 않았습니다."),
     })
-    @SecurityRequirement(name = "Bearer Authentication")
     public ResponseEntity<CommonResponse<LikesResponseDto.DeleteLikeResponseDto>> deleteLike(
             @PathVariable Long roomsId,
             @PathVariable Long likeId,

--- a/src/main/java/com/example/airdns/domain/like/controller/LikesController.java
+++ b/src/main/java/com/example/airdns/domain/like/controller/LikesController.java
@@ -4,6 +4,7 @@ import com.example.airdns.domain.like.dto.LikesResponseDto;
 import com.example.airdns.domain.like.service.LikesService;
 import com.example.airdns.global.common.dto.CommonResponse;
 import com.example.airdns.global.security.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -16,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "like", description = "Like API")
+@Tag(name = "Like", description = "Like API")
 @RequestMapping("/api/v1/rooms")
 public class LikesController {
 
@@ -25,6 +26,7 @@ public class LikesController {
     @ApiResponses(value =  {
             @ApiResponse(responseCode = "200", description = "룸에 대한 좋아요 갯수 조회"),
     })
+    @Operation(summary = "방에 대한 좋아요 갯수 조회", description = "방 전체 좋아요 조회를 한다")
     @GetMapping("/{roomsId}/likes")
     public ResponseEntity<CommonResponse<LikesResponseDto.ReadLikeResponseDto>> readRoomLike(
             @PathVariable Long roomsId){
@@ -36,6 +38,7 @@ public class LikesController {
 
     @PostMapping("/{roomsId}/likes")
     @SecurityRequirement(name = "Bearer Authentication")
+    @Operation(summary = "방에 대한 좋아요 요청", description = "방 좋아요 요청한다")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "룸 좋아요 성공"),
             @ApiResponse(responseCode = "400", description = "해당 사용자는 좋아요를 이미 눌렀습니다.")
@@ -51,6 +54,7 @@ public class LikesController {
 
     @DeleteMapping("/{roomsId}/likes/{likeId}")
     @SecurityRequirement(name = "Bearer Authentication")
+    @Operation(summary = "방에 대한 좋아요 취소 요청", description = "방 좋아요 취소를 요청한다")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "룸 좋아요 취소 성공"),
             @ApiResponse(responseCode = "400", description = "해당 사용자가 좋아요를 누르지 않았습니다."),

--- a/src/main/java/com/example/airdns/domain/like/dto/LikesResponseDto.java
+++ b/src/main/java/com/example/airdns/domain/like/dto/LikesResponseDto.java
@@ -20,6 +20,7 @@ public class LikesResponseDto {
         private Integer likeCount;
         private String roomName;
         private String ownerName;
+        private boolean userLiked;
     }
     @Getter
     @Builder
@@ -30,6 +31,7 @@ public class LikesResponseDto {
         @Schema(description = "좋아요 추가 응답 내용", defaultValue = "Create like response")
         private String nickName;
         private String roomName;
+        private boolean userLiked;
     }
 
     @Getter

--- a/src/main/java/com/example/airdns/domain/like/service/LikesServiceImplV1.java
+++ b/src/main/java/com/example/airdns/domain/like/service/LikesServiceImplV1.java
@@ -8,6 +8,7 @@ import com.example.airdns.domain.like.repository.LikesRepository;
 import com.example.airdns.domain.room.entity.Rooms;
 import com.example.airdns.domain.room.service.RoomsService;
 import com.example.airdns.domain.user.entity.Users;
+import com.example.airdns.domain.user.service.UsersService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,18 +19,24 @@ public class LikesServiceImplV1 implements LikesService {
 
     private final LikesRepository likesRepository;
     private final RoomsService roomsService;
+    private final UsersService usersService;
 
     @Override
     @Transactional(readOnly = true)
     public LikesResponseDto.ReadLikeResponseDto readRoomLike(Long roomsId){
+
         Rooms room = roomsService.findById(roomsId);
+        Users user = usersService.findById(room.getUsers().getId());
+        Boolean userLiked = likesRepository.existsByRoomsAndUsers(room, user);
 
         Integer roomLikeCount = room.getLikesList().size();
+        room.addLikeCount(roomLikeCount);
 
         return LikesResponseDto.ReadLikeResponseDto.builder()
                 .roomName(room.getName())
-                .ownerName(room.getUsers().getName())
+                .ownerName(room.getUsers().getNickname())
                 .likeCount(roomLikeCount)
+                .userLiked(userLiked)
                 .build();
     }
 
@@ -53,6 +60,7 @@ public class LikesServiceImplV1 implements LikesService {
         return LikesResponseDto.CreateLikeResponseDto.builder()
                 .roomName(room.getName())
                 .nickName(user.getNickname())
+                .userLiked(true)
                 .build();
     }
 

--- a/src/main/java/com/example/airdns/domain/room/entity/Rooms.java
+++ b/src/main/java/com/example/airdns/domain/room/entity/Rooms.java
@@ -66,6 +66,9 @@ public class Rooms extends CommonEntity {
     @JoinColumn(name = "users_id")
     private Users users;
 
+    @Column
+    private Integer likeCount;
+
     @Builder.Default
     @OneToMany(mappedBy = "rooms", cascade = CascadeType.PERSIST)
     private List<Reservation> reservationList = new ArrayList<>();
@@ -125,6 +128,9 @@ public class Rooms extends CommonEntity {
         reviewsList.add(review);
     }
 
+    public void addLikeCount(Integer likeCount){
+        this.likeCount = likeCount;
+    }
     public void addRestSchedule(RestSchedule restSchedule) {
         this.restScheduleList.add(restSchedule);
     }

--- a/src/test/java/com/example/airdns/like/LikesControllerTest.java
+++ b/src/test/java/com/example/airdns/like/LikesControllerTest.java
@@ -92,8 +92,12 @@ public class LikesControllerTest {
 
         Rooms.builder().id(roomId).users(userDetails.getUser()).name("Room Name").build();
 
-        LikesResponseDto.CreateLikeResponseDto responseDto
-                = new LikesResponseDto.CreateLikeResponseDto("testUser","Room Name"); // Assuming '10' is the new like count
+        LikesResponseDto.CreateLikeResponseDto responseDto =
+                LikesResponseDto.CreateLikeResponseDto.builder()
+                        .roomName("testUser")
+                        .roomName("Room Name")
+                        .userLiked(false)
+                        .build();
 
         when(likesService.createLike(eq(roomId), any())).thenReturn(responseDto);
 


### PR DESCRIPTION
** LikesController @SecurityRequirement 위치 수정, DTO, LikesService room에서 user가 like 확인 가능하게 변경
- [x] 좋아요 count가 방 상세 조회할 때 같이 조회 되어야함
// 방을 조회할 때, Room Entity에 LikeCount를 추가하여 이를 조회할 수 있게 변경
- [x] 방에서 좋아요를 자신이 눌렀는지 확인이 가능해야함
  - [x] 좋아요를 눌렀는지 표시되어야함
  // 좋아요를 누르면 해당 DTO에 boolean userLiked를 추가하여 해당 사항에 좋아요를 누르면 True, 좋아요 취소를 누르면 false로 변경하였습니다.
  - [x] 좋아요가 눌려있으면 좋아요 취소가 가능해야함
  // LikesService에 deleteLikes()가 존재하여 취소가 가능하고 deleteLikes를 누르면 db에서 완전 삭제
- [x] readRoomLike response 추가
  // readRoomLike의 response field : ownerName, roomName, userLiked 추가
  // createRoomLike의 response field : userLiked 추가 
- [x] 이에 따른 test code 변경

Resolves : #192